### PR TITLE
fix: correct Flutter build command syntax in workflows

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -128,8 +128,8 @@ jobs:
           echo "Building Android app for testing..."
           
           flutter build apk \
+            --target=lib/main.dart \
             --debug \
-            --target lib/main.dart \
             --dart-define=ENVIRONMENT=testing
           
           echo "Android build completed successfully"

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -148,7 +148,7 @@ jobs:
         working-directory: apps/flutter_demo
         run: |
           flutter build ios --simulator \
-            --target lib/main.dart \
+            --target=lib/main.dart \
             --debug \
             --dart-define=ENVIRONMENT=testing
       
@@ -338,7 +338,7 @@ jobs:
         working-directory: apps/flutter_demo
         run: |
           flutter build ios \
-            --target lib/main.dart \
+            --target=lib/main.dart \
             --release \
             --dart-define=ENVIRONMENT=testing
           

--- a/.github/workflows/ios-release.yml
+++ b/.github/workflows/ios-release.yml
@@ -118,9 +118,9 @@ jobs:
           
           # Build iOS release for device
           flutter build ios \
+            --target=lib/main.dart \
             --release \
             --no-codesign \
-            --target lib/main.dart \
             --dart-define=ENVIRONMENT=production \
             --build-name=${{ env.RELEASE_VERSION }} \
             --build-number=${{ env.BUILD_NUMBER }}


### PR DESCRIPTION
- Fix --target flag syntax to use --target=lib/main.dart format
- Apply fix across ios-release.yml, ios-e2e.yml, and android-e2e.yml
- Resolve 'Could not find an option named target' error
- Ensure proper parameter ordering for Flutter CLI commands

This fixes the iOS release build workflow that was failing due to incorrect Flutter command syntax.