### PR TITLE
Remove path filters from workflows to run all checks on PRs

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -3,20 +3,8 @@ name: Android E2E Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - 'test/e2e/**'
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - '.github/workflows/android-e2e.yml'
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - 'test/e2e/**'
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - '.github/workflows/android-e2e.yml'
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/android-testing.yml
+++ b/.github/workflows/android-testing.yml
@@ -1,16 +1,10 @@
 name: Android Testing (Widget Tests)
 
-on: 
+on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - '.github/workflows/android-testing.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - '.github/workflows/android-testing.yml'
+    branches: [ main, develop ]
 
 jobs:
   widget-tests:

--- a/.github/workflows/demo-validation.yml
+++ b/.github/workflows/demo-validation.yml
@@ -3,20 +3,8 @@ name: Demo Tests Validation
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'test/e2e/demo_*.dart'
-      - 'test/e2e/summary_test.dart'
-      - 'test/e2e/README.md'
-      - 'test/e2e/IMPLEMENTATION_SUMMARY.md'
-      - '.github/workflows/demo-validation.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'test/e2e/demo_*.dart'
-      - 'test/e2e/summary_test.dart'
-      - 'test/e2e/README.md'
-      - 'test/e2e/IMPLEMENTATION_SUMMARY.md'
-      - '.github/workflows/demo-validation.yml'
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/flutter-integration.yml
+++ b/.github/workflows/flutter-integration.yml
@@ -3,16 +3,8 @@ name: Flutter Integration Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'test/e2e/flutter/**'
-      - 'apps/flutter_demo/integration_test/**'
-      - '.github/workflows/flutter-integration.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'test/e2e/flutter/**'
-      - 'apps/flutter_demo/integration_test/**'
-      - '.github/workflows/flutter-integration.yml'
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/integration-config.yml
+++ b/.github/workflows/integration-config.yml
@@ -3,18 +3,8 @@ name: Integration Configuration Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'test/integration/**'
-      - '.ci/**'
-      - 'docker-compose*.yml'
-      - '.github/workflows/integration-config.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'test/integration/**'
-      - '.ci/**'
-      - 'docker-compose*.yml'
-      - '.github/workflows/integration-config.yml'
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -3,20 +3,8 @@ name: iOS E2E Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - 'test/e2e/**'
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - '.github/workflows/ios-e2e.yml'
   pull_request:
     branches: [ main, develop ]
-    paths:
-      - 'apps/flutter_demo/**'
-      - 'test/e2e/**'
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - '.github/workflows/ios-e2e.yml'
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/mobile-lifecycle.yml
+++ b/.github/workflows/mobile-lifecycle.yml
@@ -3,18 +3,8 @@ name: Mobile Lifecycle Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - 'test/e2e/drivers/mobile_lifecycle_manager.dart'
-      - '.github/workflows/mobile-lifecycle.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'test/e2e/tests/mobile_lifecycle_test.dart'
-      - 'test/e2e/scenarios/mobile_lifecycle_scenarios.dart'
-      - 'test/e2e/drivers/mobile_lifecycle_manager.dart'
-      - '.github/workflows/mobile-lifecycle.yml'
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       test_suite:

--- a/.github/workflows/network-testing.yml
+++ b/.github/workflows/network-testing.yml
@@ -3,16 +3,8 @@ name: Network State Testing
 on:
   push:
     branches: [ main, develop ]
-    paths:
-      - 'test/e2e/network/**'
-      - 'test/e2e/drivers/network_state_manager.dart'
-      - '.github/workflows/network-testing.yml'
   pull_request:
-    branches: [ main ]
-    paths:
-      - 'test/e2e/network/**'
-      - 'test/e2e/drivers/network_state_manager.dart'
-      - '.github/workflows/network-testing.yml'
+    branches: [ main, develop ]
   workflow_dispatch:
     inputs:
       test_suite:


### PR DESCRIPTION
- Remove paths restrictions from android-e2e.yml
- Remove paths restrictions from flutter-integration.yml
- Remove paths restrictions from demo-validation.yml
- Remove paths restrictions from network-testing.yml
- Remove paths restrictions from mobile-lifecycle.yml
- Remove paths restrictions from integration-config.yml
- Remove paths restrictions from android-testing.yml
- Remove paths restrictions from ios-e2e.yml
- Expand pull_request branches to include develop for all workflows

Now all workflows will run on any PR to main/develop branches