### PR TITLE
feat(mqtt): allow username/password over non-TLS by configuration cho…

### DIFF
--- a/packages/merkle_kv_core/lib/src/mqtt/mqtt_client_impl.dart
+++ b/packages/merkle_kv_core/lib/src/mqtt/mqtt_client_impl.dart
@@ -52,11 +52,10 @@ class MqttClientImpl implements MqttClientInterface {
     _client.autoReconnect = false; // We handle reconnection manually
     _client.logging(on: false); // Prevent credential logging
 
-    // TLS enforcement when credentials are present
-    if ((_config.username != null || _config.password != null) &&
-        !_config.mqttUseTls) {
-      throw ArgumentError('TLS must be enabled when credentials are provided');
-    }
+    // Note: We no longer hard-enforce TLS when credentials are present.
+    // A security warning is emitted at config validation time if credentials
+    // are provided without TLS. Allowing this here supports brokers that use
+    // plaintext auth on trusted networks by explicit user choice.
 
     // Apply TLS/security configuration
     final sec = _config.mqttSecurity;
@@ -184,8 +183,10 @@ class MqttClientImpl implements MqttClientInterface {
       });
 
       // Handle authentication
-      if (_config.username != null && _config.password != null) {
-        _client.connect(_config.username!, _config.password!).then((status) {
+      if (_config.username != null || _config.password != null) {
+        final user = _config.username ?? '';
+        final pass = _config.password ?? '';
+        _client.connect(user, pass).then((status) {
           timeoutTimer?.cancel();
           if (!connectionCompleter.isCompleted) {
             connectionCompleter.complete(status);

--- a/packages/merkle_kv_core/lib/src/mqtt/mqtt_client_impl.dart
+++ b/packages/merkle_kv_core/lib/src/mqtt/mqtt_client_impl.dart
@@ -184,19 +184,36 @@ class MqttClientImpl implements MqttClientInterface {
 
       // Handle authentication
       if (_config.username != null || _config.password != null) {
-        final user = _config.username ?? '';
-        final pass = _config.password ?? '';
-        _client.connect(user, pass).then((status) {
+        final user = _config.username;
+        final pass = _config.password;
+        final hasUser = user != null && user.isNotEmpty;
+        final hasPass = pass != null && pass.isNotEmpty;
+        if (hasUser || hasPass) {
+          _client.connect(user ?? '', pass ?? '').then((status) {
           timeoutTimer?.cancel();
           if (!connectionCompleter.isCompleted) {
             connectionCompleter.complete(status);
           }
-        }).catchError((error) {
+          }).catchError((error) {
           timeoutTimer?.cancel();
           if (!connectionCompleter.isCompleted) {
             connectionCompleter.completeError(error);
           }
-        });
+          });
+        } else {
+          // Both username and password are empty strings; attempt anonymous connect
+          _client.connect().then((status) {
+            timeoutTimer?.cancel();
+            if (!connectionCompleter.isCompleted) {
+              connectionCompleter.complete(status);
+            }
+          }).catchError((error) {
+            timeoutTimer?.cancel();
+            if (!connectionCompleter.isCompleted) {
+              connectionCompleter.completeError(error);
+            }
+          });
+        }
       } else {
         _client.connect().then((status) {
           timeoutTimer?.cancel();

--- a/packages/merkle_kv_core/test/mqtt/mqtt_client_impl_test.dart
+++ b/packages/merkle_kv_core/test/mqtt/mqtt_client_impl_test.dart
@@ -37,27 +37,22 @@ void main() {
         expect(client.connectionState, isA<Stream<ConnectionState>>());
       });
 
-      test('enforces TLS when credentials are present', () {
-        expect(
-          () => MqttClientImpl(
-            MerkleKVConfig(
-              mqttHost: 'localhost',
-              mqttPort: 1883,
-              clientId: 'test-client',
-              nodeId: 'test-node',
-              mqttUseTls: false,
-              username: 'user',
-              password: 'pass',
-            ),
-          ),
-          throwsA(
-            isA<ArgumentError>().having(
-              (e) => e.message,
-              'message',
-              contains('TLS must be enabled when credentials are provided'),
-            ),
+      test('allows credentials without TLS (warn-only)', () {
+        // Policy updated: credentials over non-TLS are allowed; client should construct normally.
+        client = MqttClientImpl(
+          MerkleKVConfig(
+            mqttHost: 'localhost',
+            mqttPort: 1883,
+            clientId: 'test-client',
+            nodeId: 'test-node',
+            mqttUseTls: false,
+            username: 'user',
+            password: 'pass',
           ),
         );
+
+        // Verify the client is created and exposes the expected interface.
+        expect(client.connectionState, isA<Stream<ConnectionState>>());
       });
 
       test('configures TLS correctly when enabled', () {


### PR DESCRIPTION
…ice; warn only\n\n- Remove hard TLS requirement in MQTT client implementation\n- Accept password-only or username-only auth by sending empty counterpart\n- Security warning remains in config validation